### PR TITLE
"use strict"; should not be used globally ...

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-async-sugar",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Drop-in sugar for Jasmine test framework to enhance testing of async (promise) functionality to be used with Angular 1.X",
   "repository": {
     "type": "git",

--- a/jasmine-async-sugar.js
+++ b/jasmine-async-sugar.js
@@ -1,6 +1,5 @@
-'use strict';
-
 (function (global, undefined) {
+    'use strict';
 
     var MODULE_NAME = 'jasmine-async-sugar';
     var JASMINE_FUNCTIONS = ['it', 'fit', 'xit', 'beforeEach', 'afterEach', 'beforeAll', 'afterAll'];
@@ -15,7 +14,7 @@
         JASMINE_FUNCTIONS.forEach(function (jasmineFunctionName) {
 
             if (!global[jasmineFunctionName]) {
-                console.error(MODULE_NAME, 'Jasmine function: ' + jasmineFunctionName + ' not present in environment');
+                window.console.error(MODULE_NAME, 'Jasmine function: ' + jasmineFunctionName + ' not present in environment');
                 return;
             }
             var jasmineFunctionNameAsync = jasmineFunctionName + ASYNC_SUFIX;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-async-sugar",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Drop-in sugar for Jasmine test framework to enhance testing of async (promise) functionality to be used with Angular 1.X",
   "main": "jasmine-async-sugar.js",
   "scripts": {


### PR DESCRIPTION
... because when concatenating jasmine-async-sugar.js with other files, this might interfere in a way one would not expect to (making everything "use strict";)
