### PR TITLE
Improve error handling

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-async-sugar",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Drop-in sugar for Jasmine test framework to enhance testing of async (promise) functionality to be used with Angular 1.X",
   "repository": {
     "type": "git",
@@ -30,7 +30,7 @@
   ],
   "license": "MIT",
   "devDependencies": {
-    "angular": "~1.5.3",
-    "angular-mocks": "~1.5.3"
+    "angular": "~1.5.8",
+    "angular-mocks": "~1.5.8"
   }
 }

--- a/jasmine-async-sugar.js
+++ b/jasmine-async-sugar.js
@@ -106,6 +106,15 @@
                             //The thrown error will leave angular thinking
                             //it still is digesting, here we stop it from doing so.
                             $rootScope.$$phase = null;
+                            if (Array.isArray($rootScope.$$asyncQueue)) {
+                                $rootScope.$$asyncQueue.splice(0);
+                            }
+                            if (Array.isArray($rootScope.$$postDigestQueue)) {
+                                $rootScope.$$postDigestQueue.splice(0);
+                            }
+                            if (Array.isArray($rootScope.$$applyAsyncQueue)) {
+                                $rootScope.$$applyAsyncQueue.splice(0);
+                            }
                         }
                         flushTimeout($timeout);
                         flushHttp($httpBackend);

--- a/jasmine-async-sugar.js
+++ b/jasmine-async-sugar.js
@@ -100,34 +100,24 @@
                         var $timeout = angularContext.$injector.get('$timeout');
                         var $httpBackend = angularContext.$injector.get('$httpBackend');
 
-                        try {
-                            $rootScope.$digest();
-                        }catch(e){
-                            //The thrown error will leave angular thinking
-                            //it still is digesting, here we stop it from doing so.
-                            $rootScope.$$phase = null;
-                            if (Array.isArray($rootScope.$$asyncQueue)) {
-                                $rootScope.$$asyncQueue.splice(0);
-                            }
-                            if (Array.isArray($rootScope.$$postDigestQueue)) {
-                                $rootScope.$$postDigestQueue.splice(0);
-                            }
-                            if (Array.isArray($rootScope.$$applyAsyncQueue)) {
-                                $rootScope.$$applyAsyncQueue.splice(0);
-                            }
-                        }
+                        runDigest($rootScope);
                         flushTimeout($timeout);
                         flushHttp($httpBackend);
+                    }
+
+                    function runDigest($rootScope) {
+                        try {
+                            $rootScope.$digest();
+                        } catch (err) {
+                            handleError(err);
+                        }
                     }
 
                     function flushHttp($httpBackend) {
                         try {
                             $httpBackend.flush();
                         } catch (err) {
-                            //no pending request to be flushed, that's ok with me
-                            if (err.message !== 'No pending request to flush !') {
-                                handleError(err);
-                            }
+                            handleError(err);
                         }
                     }
 
@@ -138,10 +128,7 @@
                         try {
                             $timeout.flush();
                         } catch (err) {
-                            //no deferred tasks to be flushed, that's ok with me
-                            if (err.message !== 'No deferred tasks to be flushed') {
-                                handleError(err);
-                            }
+                            handleError(err);
                         }
                     }
 
@@ -154,7 +141,7 @@
                                           // handler triggers a $digest() which is not possible if we're alredy in a $digest phase.
                     }
 
-                    function failDoneAndClearInterval(msg){
+                    function failDoneAndClearInterval(msg) {
                         clearInterval(intervalId);
                         finished = true;
 
@@ -162,27 +149,54 @@
                         // will run OUTSIDE of a $digest phase. This is important when mimicking
                         // a user clicking on elements in follow-up steps, because a ng-click event
                         // handler triggers a $digest() which is not possible if we're alredy in a $digest phase.
-                        setTimeout(function() {
+                        setTimeout(function () {
                             done.fail(msg);
                         });
                     }
 
                     function handleError(error) {
-                        var message;
-                        if(error instanceof Error){
-                            message = error.stack;
-                        }else if(typeof error === 'string' || typeof error === 'number'){
-                            message = error;
-                        }else {
-                            try {
-                                message = JSON.stringify(error);
-                            }catch(err){
-                                message = error;
+                        //
+                        // Thrown errors may leave angular thinking that it is still digesting: here we stop it from doing so.
+                        // Additionally, we reset the internal queues because because since recently, angular no longer shifts the queues
+                        // while processing them, but only resets them AFTER all tasks have successfully run (which does not work with
+                        // rethrowing errors in angular-mocks.js).
+                        //
+                        var $rootScope = angularContext && angularContext.$injector && angularContext.$injector.get('$rootScope');
+                        if ($rootScope) {
+                            $rootScope.$$phase = null;
+                            if (Array.isArray($rootScope.$$asyncQueue)) {
+                                $rootScope.$$asyncQueue.splice(0); // we use splice to preserve object identity
+                            }
+                            if (Array.isArray($rootScope.$$postDigestQueue)) {
+                                $rootScope.$$postDigestQueue.splice(0); // we use splice to preserve object identity
+                            }
+                            if (Array.isArray($rootScope.$$applyAsyncQueue)) {
+                                $rootScope.$$applyAsyncQueue.splice(0); // we use splice to preserve object identity
                             }
                         }
-                        clearInterval(intervalId);
-                        finished = true;
-                        done.fail(message);
+
+                        // No deferred tasks to be flushed, that's ok with me
+                        if (error.message !== 'No deferred tasks to be flushed' //
+                            && error.message !== 'No pending request to flush !')
+                        {
+                            var message;
+                            if (error instanceof Error) {
+                                message = error; // jasmine can handle Error objects better than strings, so we don't give error.stack!
+                            }
+                            else if (typeof error === 'string' || typeof error === 'number') {
+                                message = error;
+                            }
+                            else {
+                                try {
+                                    message = JSON.stringify(error);
+                                } catch (err) {
+                                    message = error;
+                                }
+                            }
+                            clearInterval(intervalId);
+                            finished = true;
+                            done.fail(message);
+                        }
                     }
 
                 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-async-sugar",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Drop-in sugar for Jasmine test framework to enhance testing of async (promise) functionality to be used with Angular 1.X",
   "main": "jasmine-async-sugar.js",
   "scripts": {


### PR DESCRIPTION
Errors now hould no longer be swallowed but instead be properly forwarded to jasmine.

Additionally:
Angular 1.5.6 introduced a performance improvement on internal queue handling. This leads to confusing follow-up errors after the first error during a $digest in a module.sharedInjector() setup. These follow-up errors now don't show up any more.